### PR TITLE
네이버지도 API 연동

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,14 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
+    <script
+      type="text/javascript"
+      src="https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=%VITE_REACT_APP_NAVER_MAP_API_KEY%"
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
+        "@types/navermaps": "^3.7.10",
         "@types/node": "^22.15.18",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
@@ -1318,11 +1319,26 @@
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
       "dev": true
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/navermaps": {
+      "version": "3.7.10",
+      "resolved": "https://registry.npmjs.org/@types/navermaps/-/navermaps-3.7.10.tgz",
+      "integrity": "sha512-lYOC2afpIo54OTLcDmMy1gD2BWEj8l8AbgkCmLSWJ9doSVOIDtLNNHn0faJxzvAOmwvu1JSwO/IV5OtMHIblzw==",
+      "dev": true,
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "22.15.18",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
+    "@types/navermaps": "^3.7.10",
     "@types/node": "^22.15.18",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",

--- a/src/api/receipt.ts
+++ b/src/api/receipt.ts
@@ -8,7 +8,7 @@ import type { ReceiptAndOrdersResponse } from '../types/Receipt';
  */
 export const createReceipt = async (
   storeId: number,
-  tableId: number
+  tableId: string
 ): Promise<{ id: string }> => {
   const response = await axiosInstance.post<{ id: string }>(
     `/api/v1/receipts?storeId=${storeId}&tableId=${tableId}`
@@ -19,7 +19,7 @@ export const createReceipt = async (
 /**
  * 대상 테이블의 미정산 영수증 ID를 조회하는 API
  */
-export const getNonAdjustReceipt = async (tableId: number): Promise<string | null> => {
+export const getNonAdjustReceipt = async (tableId: string): Promise<string | null> => {
   const response = await axiosInstance.get<ApiResponse<ReceiptIdData>>(
     `/api/v1/table/${tableId}/receipts/non-adjust`
   );

--- a/src/components/NaverMap/NaverMap.module.css
+++ b/src/components/NaverMap/NaverMap.module.css
@@ -1,0 +1,4 @@
+.map {
+  width: 100%;
+  height: 300px;
+}

--- a/src/components/NaverMap/NaverMap.tsx
+++ b/src/components/NaverMap/NaverMap.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from "react";
+
+const NaverMap = () => {
+  const { naver } = window;
+  const mapOptions = {
+    center: new naver.maps.LatLng(37.3595704, 127.105399),
+    zoom: 10,
+  };
+  const map = new naver.maps.Map("map", mapOptions);
+
+  return <div id="map" style={{ width: "100%", height: "500px" }} />;
+  //   const mapRef = useRef(null);
+  //   const [currentLocation, setCurrentLocation] = useState({
+  //     latitude: 37.123456,
+  //     longitude: 127.123456,
+  //   });
+
+  //   const success = () => {
+  //     setCurrentLocation({
+  //       latitude: 37.123456,
+  //       longitude: 127.123456,
+  //     });
+  //   };
+
+  //   const error = () => {
+  //     setCurrentLocation({
+  //       latitude: 37.123456,
+  //       longitude: 127.123456,
+  //     });
+  //   };
+
+  //   //   let map: naver.maps.Map;
+  //   //   const center: naver.maps.LatLng = new naver.maps.LatLng(
+  //   //     37.3595704,
+  //   //     127.105399
+  //   //   );
+
+  //   //   map = new naver.maps.Map("map", {
+  //   //     center: center,
+  //   //     zoom: 16,
+  //   //   });
+
+  //   //   useEffect(() => {
+  //   //     const mapOptions = {
+  //   //       center: new naver.maps.LatLng(37.511337, 127.012084),
+  //   //       logoControl: false,
+  //   //       tileDuration: 200,
+  //   //       zoom: 10,
+  //   //     };
+  //   //     mapRef.current = new naver.maps.Map("map", mapOptions);
+  //   //   }, []);
+  //   const map = new naver.maps.Map("map", {
+  //     center: new naver.maps.LatLng(37.3595704, 127.105399),
+  //     zoom: 15,
+  //   });
+
+  //   const marker = new naver.maps.Marker({
+  //     position: new naver.maps.LatLng(37.3595704, 127.105399),
+  //     map: map,
+  //   });
+
+  //   return <div id="map"></div>;
+};
+
+export default NaverMap;

--- a/src/components/NaverMap/NaverMap.tsx
+++ b/src/components/NaverMap/NaverMap.tsx
@@ -15,15 +15,17 @@ const NaverMap = ({ latitude, longitude }: LocationType) => {
       zoom: 18,
     };
 
-    const map = new naver.maps.Map("map", mapOptions);
+    const map = new naver.maps.Map("naverMap", mapOptions);
 
     const marker = new naver.maps.Marker({
       position: new naver.maps.LatLng(latitude, longitude),
       map: map,
     });
-  }, []);
 
-  return <div id="map" className={style.map} />;
+    return () => marker.setMap(null);
+  }, [latitude, longitude]);
+
+  return <div id="naverMap" className={style.map} />;
 };
 
 export default NaverMap;

--- a/src/components/NaverMap/NaverMap.tsx
+++ b/src/components/NaverMap/NaverMap.tsx
@@ -1,65 +1,29 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect } from "react";
+import style from "./NaverMap.module.css";
+type LocationType = {
+  latitude: number;
+  longitude: number;
+};
 
-const NaverMap = () => {
-  const { naver } = window;
-  const mapOptions = {
-    center: new naver.maps.LatLng(37.3595704, 127.105399),
-    zoom: 10,
-  };
-  const map = new naver.maps.Map("map", mapOptions);
+const NaverMap = ({ latitude, longitude }: LocationType) => {
+  useEffect(() => {
+    const { naver } = window;
+    if (!naver) return;
 
-  return <div id="map" style={{ width: "100%", height: "500px" }} />;
-  //   const mapRef = useRef(null);
-  //   const [currentLocation, setCurrentLocation] = useState({
-  //     latitude: 37.123456,
-  //     longitude: 127.123456,
-  //   });
+    const mapOptions = {
+      center: new naver.maps.LatLng(latitude, longitude),
+      zoom: 18,
+    };
 
-  //   const success = () => {
-  //     setCurrentLocation({
-  //       latitude: 37.123456,
-  //       longitude: 127.123456,
-  //     });
-  //   };
+    const map = new naver.maps.Map("map", mapOptions);
 
-  //   const error = () => {
-  //     setCurrentLocation({
-  //       latitude: 37.123456,
-  //       longitude: 127.123456,
-  //     });
-  //   };
+    const marker = new naver.maps.Marker({
+      position: new naver.maps.LatLng(latitude, longitude),
+      map: map,
+    });
+  }, []);
 
-  //   //   let map: naver.maps.Map;
-  //   //   const center: naver.maps.LatLng = new naver.maps.LatLng(
-  //   //     37.3595704,
-  //   //     127.105399
-  //   //   );
-
-  //   //   map = new naver.maps.Map("map", {
-  //   //     center: center,
-  //   //     zoom: 16,
-  //   //   });
-
-  //   //   useEffect(() => {
-  //   //     const mapOptions = {
-  //   //       center: new naver.maps.LatLng(37.511337, 127.012084),
-  //   //       logoControl: false,
-  //   //       tileDuration: 200,
-  //   //       zoom: 10,
-  //   //     };
-  //   //     mapRef.current = new naver.maps.Map("map", mapOptions);
-  //   //   }, []);
-  //   const map = new naver.maps.Map("map", {
-  //     center: new naver.maps.LatLng(37.3595704, 127.105399),
-  //     zoom: 15,
-  //   });
-
-  //   const marker = new naver.maps.Marker({
-  //     position: new naver.maps.LatLng(37.3595704, 127.105399),
-  //     map: map,
-  //   });
-
-  //   return <div id="map"></div>;
+  return <div id="map" className={style.map} />;
 };
 
 export default NaverMap;

--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -4,6 +4,7 @@ const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_REACT_APP_BASE_URL,
   headers: {
     'Content-Type': 'application/json',
+    'ngrok-skip-browser-warning': 'true'
   },
 });
 

--- a/src/pages/StoreDetail/StoreDetail.module.css
+++ b/src/pages/StoreDetail/StoreDetail.module.css
@@ -76,3 +76,8 @@
   color: #888;
   font-size: 16px;
 }
+
+.naverMap {
+  height: 300px;
+  background-color: aliceblue;
+}

--- a/src/pages/StoreDetail/StoreDetail.module.css
+++ b/src/pages/StoreDetail/StoreDetail.module.css
@@ -1,7 +1,6 @@
 .storeDetail {
   display: flex;
   flex-direction: column;
-  background-color: #ececec;
 }
 
 .scrollImg {
@@ -48,13 +47,13 @@
   right: 16px;
 }
 
-.menuList {
+.selectedInfo {
   margin: 0;
 }
 
 .menuBar {
   display: flex;
-  margin-top: 10px;
+  border-top: 10px solid #ececec;
 }
 
 .menuBar > button {
@@ -67,9 +66,10 @@
   color: #9f9f9f;
   border-bottom: 2px solid #f5f5f5;
   padding: 18px;
+  cursor: pointer;
 }
 
-.menuBar > button:focus {
+.menuBar > button.selected {
   border-bottom: 2px solid #6299fe;
 }
 
@@ -98,6 +98,8 @@
 }
 
 .naverMap {
-  height: 300px;
-  background-color: aliceblue;
+  overflow: hidden;
+  margin: 16px;
+  border-radius: 20px;
+  overflow: hidden;
 }

--- a/src/pages/StoreDetail/StoreDetail.module.css
+++ b/src/pages/StoreDetail/StoreDetail.module.css
@@ -50,7 +50,27 @@
 
 .menuList {
   margin: 0;
+}
+
+.menuBar {
+  display: flex;
   margin-top: 10px;
+}
+
+.menuBar > button {
+  flex: 1;
+  text-align: center;
+  font-size: 14px;
+  font-weight: 600;
+  border: none;
+  background-color: white;
+  color: #9f9f9f;
+  border-bottom: 2px solid #f5f5f5;
+  padding: 18px;
+}
+
+.menuBar > button:focus {
+  border-bottom: 2px solid #6299fe;
 }
 
 .menuCategory {
@@ -75,4 +95,9 @@
   background-color: #f1f1f1;
   color: #888;
   font-size: 16px;
+}
+
+.naverMap {
+  height: 300px;
+  background-color: aliceblue;
 }

--- a/src/pages/StoreDetail/StoreDetail.tsx
+++ b/src/pages/StoreDetail/StoreDetail.tsx
@@ -16,7 +16,6 @@ const StoreDetail = () => {
   const [storeInfo, setStoreInfo] = useState<StoreResponse>();
   const [imgSlide, setImgSlide] = useState<string[]>([]);
   const [currentImg, setCurrentImg] = useState(0);
-  const [isSelectedMap, setSelectedMap] = useState(false);
   const length = imgSlide.length;
 
   const [startX, setStartX] = useState<number | null>(null);
@@ -121,7 +120,14 @@ const StoreDetail = () => {
           <>
             {selectedMenuBar === "map" ? (
               <div className={style.naverMap}>
-                <NaverMap latitude={36.146} longitude={128.3933} />
+                {storeInfo.latitude && storeInfo.longitude ? (
+                  <NaverMap
+                    latitude={storeInfo.latitude}
+                    longitude={storeInfo.longitude}
+                  />
+                ) : (
+                  <div>가게 위치 정보가 없습니다.</div>
+                )}
               </div>
             ) : (
               <Menu storeId={storeInfo.storeId} />

--- a/src/pages/StoreDetail/StoreDetail.tsx
+++ b/src/pages/StoreDetail/StoreDetail.tsx
@@ -8,6 +8,7 @@ import { getStoreInfo } from "../../api/store";
 import Menu from "../Menu/Menu";
 import { toast } from "react-toastify";
 import Loading from "../../components/Loading/Loading";
+import NaverMap from "../../components/NaverMap/NaverMap";
 
 const StoreDetail = () => {
   const location = useLocation();
@@ -15,6 +16,7 @@ const StoreDetail = () => {
   const [storeInfo, setStoreInfo] = useState<StoreResponse>();
   const [imgSlide, setImgSlide] = useState<string[]>([]);
   const [currentImg, setCurrentImg] = useState(0);
+  const [isSelectedMap, setSelectedMap] = useState(false);
   const length = imgSlide.length;
 
   const [startX, setStartX] = useState<number | null>(null);
@@ -94,8 +96,15 @@ const StoreDetail = () => {
         <StoreInfo storeInfo={storeInfo} />
       </div>
 
+      <div className={style.menuBar}>
+        <button>메뉴</button>
+        <button>위치보기</button>
+      </div>
+      <div className={style.naverMap}>
+        <NaverMap />
+      </div>
       <div className={style.menuList}>
-        <div className={style.menuCategory} />
+        {/* 메뉴바 중 뭘 선택하냐에 따라 렌더링 다르게 */}
         {storeInfo ? (
           <Menu storeId={storeInfo.storeId} />
         ) : (

--- a/src/pages/StoreDetail/StoreDetail.tsx
+++ b/src/pages/StoreDetail/StoreDetail.tsx
@@ -22,6 +22,10 @@ const StoreDetail = () => {
   const [startX, setStartX] = useState<number | null>(null);
   const [endX, setEndX] = useState<number | null>(null);
 
+  const [selectedMenuBar, setSelectedMenuBar] = useState<"menu" | "map">(
+    "menu"
+  );
+
   const nextSlide = () => {
     setCurrentImg(currentImg === length - 1 ? 0 : currentImg + 1);
   };
@@ -91,24 +95,44 @@ const StoreDetail = () => {
       ) : (
         <div className={style.noImage}>이미지가 없습니다.</div>
       )}
-
-      <div className={style.storeInfo}>
+      <div>
         <StoreInfo storeInfo={storeInfo} />
       </div>
-
       <div className={style.menuBar}>
-        <button>메뉴</button>
-        <button>위치보기</button>
+        <button
+          className={`${style.button} ${
+            selectedMenuBar === "menu" ? style.selected : ""
+          }`}
+          onClick={() => setSelectedMenuBar("menu")}
+        >
+          메뉴
+        </button>
+        <button
+          className={`${style.button} ${
+            selectedMenuBar === "map" ? style.selected : ""
+          }`}
+          onClick={() => setSelectedMenuBar("map")}
+        >
+          위치보기
+        </button>
       </div>
-      <div className={style.naverMap}>
-        <NaverMap />
-      </div>
-      <div className={style.menuList}>
-        {/* 메뉴바 중 뭘 선택하냐에 따라 렌더링 다르게 */}
+      <div className={style.selectedInfo}>
         {storeInfo ? (
-          <Menu storeId={storeInfo.storeId} />
+          <>
+            {selectedMenuBar === "map" ? (
+              <div className={style.naverMap}>
+                <NaverMap latitude={36.146} longitude={128.3933} />
+              </div>
+            ) : (
+              <Menu storeId={storeInfo.storeId} />
+            )}
+          </>
         ) : (
-          <Loading msg="가게 메뉴 정보를 불러오지 못했습니다." />
+          <Loading
+            msg={`${
+              selectedMenuBar === "map" ? "가게 위치" : "가게 메뉴"
+            } 정보를 불러오지 못했습니다.`}
+          />
         )}
       </div>
     </div>

--- a/src/pages/TableValidationPage/TableValidationPage.tsx
+++ b/src/pages/TableValidationPage/TableValidationPage.tsx
@@ -11,11 +11,11 @@ const TableValidationPage = () => {
   const [loadingMessage, setLoadingMessage] =
     useState("테이블 정보를 확인 중입니다...");
 
-  const tableId = Number(searchParams.get("tableid"));
+  const tableId = searchParams.get("tableid");
   const storeId = Number(searchParams.get("storeid"));
 
   useEffect(() => {
-    if (!tableId || !storeId || isNaN(tableId) || isNaN(storeId)) {
+    if (!tableId || !storeId || isNaN(storeId)) {
       toast.error("올바르지 않은 QR 코드입니다. 매장 직원에게 문의해주세요.");
       return;
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #17 

<br>

## 📝 작업 내용
- 가게위치 추가를 위한 메뉴바 추가
- 네이버지도 API 연동

<br>

## 📸 스크린샷
|가게위치 표시|
|---|
|<img src="https://github.com/user-attachments/assets/0184c2e0-78b4-4268-8e52-a7b2f70e03d3" width=300>|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 매장 상세 페이지에서 메뉴와 위치(네이버 지도) 탭 전환 기능이 추가되었습니다.
  - 네이버 지도 API가 적용된 지도 컴포넌트가 도입되었습니다.

- **버그 수정**
  - 테이블 검증 페이지에서 테이블 ID 처리 방식이 문자열로 변경되어 QR 코드 인식이 개선되었습니다.

- **스타일**
  - 매장 상세 페이지의 탭 및 지도 영역에 대한 스타일이 개선되었습니다.
  - 네이버 지도 컴포넌트에 전용 스타일이 추가되었습니다.

- **기타**
  - 네이버 지도 타입 지원 패키지가 개발 의존성으로 추가되었습니다.
  - 일부 API 함수의 테이블 ID 파라미터 타입이 문자열로 변경되었습니다.
  - axios 인스턴스에 ngrok 경고 방지 헤더가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->