### PR TITLE
두 번째 QA

### DIFF
--- a/src/components/StoreItem/StoreItem.tsx
+++ b/src/components/StoreItem/StoreItem.tsx
@@ -36,11 +36,7 @@ const StoreItem = ({
 
           return (
             <div key={index} className={style.storeInfoImageUrlItem}>
-              <img
-                src={fixedUrl}
-                alt={`가게 이미지 ${index + 1}`}
-                referrerPolicy="no-referrer"
-              />
+              <img src={fixedUrl} alt={`가게 이미지 ${index + 1}`} />
             </div>
           );
         })}

--- a/src/components/StoreItem/StoreItem.tsx
+++ b/src/components/StoreItem/StoreItem.tsx
@@ -8,7 +8,13 @@ type StoreItemProps = {
   storeInfoImageUrl: string[]; // 가게 상세 이미지 리스트
 };
 
-const StoreItem = ({ storeName, isOpened, headImageUrl, description, storeInfoImageUrl }: StoreItemProps) => {
+const StoreItem = ({
+  storeName,
+  isOpened,
+  headImageUrl,
+  description,
+  storeInfoImageUrl,
+}: StoreItemProps) => {
   return (
     <div className={style.storeItem}>
       <div className={style.storeInfo}>
@@ -22,11 +28,22 @@ const StoreItem = ({ storeName, isOpened, headImageUrl, description, storeInfoIm
         </div>
       </div>
       <div className={style.storeInfoImageUrl}>
-        {storeInfoImageUrl.map((item, index) => (
-          <div key={index} className={style.storeInfoImageUrlItem}>
-            <img src={item} alt={`가게 이미지 ${index + 1}`} />
-          </div>
-        ))}
+        {storeInfoImageUrl.map((url, index) => {
+          const fixedUrl =
+            url.startsWith("https:/") && !url.startsWith("https://")
+              ? url.replace("https:/", "https://")
+              : url;
+
+          return (
+            <div key={index} className={style.storeInfoImageUrlItem}>
+              <img
+                src={fixedUrl}
+                alt={`가게 이미지 ${index + 1}`}
+                referrerPolicy="no-referrer"
+              />
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/pages/StoreDetail/StoreDetail.module.css
+++ b/src/pages/StoreDetail/StoreDetail.module.css
@@ -9,6 +9,7 @@
   aspect-ratio: 1 / 1;
   overflow: hidden;
   position: relative;
+  width: 100%;
 }
 
 .scrollImg img {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #22 

<br>

## 📝 작업 내용
- 가게 상세 페이지에서 가게 대표 이미지가 가로 길이 전체를 차지하지 않는 문제 해결

<br>

## 📸 스크린샷
|before|after|
|---|---|
|![image](https://github.com/user-attachments/assets/8b29585f-e99a-4cf6-8c24-6a7d2dc3ebbc)|![image](https://github.com/user-attachments/assets/f887d2fd-fe02-4143-9470-ee020c7d9c12)|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - `.scrollImg` 클래스에 `width: 100%`가 추가되어 이미지가 컨테이너의 가로 공간을 모두 차지하도록 개선되었습니다.
- **Bug Fixes**
  - 이미지 URL이 올바르게 표시되도록 "https:/"로 시작하는 URL을 "https://"로 자동 수정하는 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->