### PR TITLE
사진 클릭 시 전체화면 팝업 구현

### DIFF
--- a/src/components/MenuItem/MenuItem.module.css
+++ b/src/components/MenuItem/MenuItem.module.css
@@ -53,3 +53,33 @@
   font-size: 16px;
   font-weight: bold;
 }
+
+.popupOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.popupContent {
+  background-color: white;
+  padding: 16px;
+  border-radius: 8px;
+  max-width: 90%;
+  max-height: 90%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.popupContent img {
+  max-width: 100%;
+  max-height: 100%;
+  border-radius: 8px;
+}

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import style from "./MenuItem.module.css";
 import Tag from "../Tag/Tag";
 import type { MenuInfoResponse } from "../../types/Menu";
@@ -8,23 +9,44 @@ type MenuItemProps = {
 };
 
 const MenuItem = ({ menu, onClick }: MenuItemProps) => {
+  const [isPopupOpen, setIsPopupOpen] = useState(false);
+
+  const handleImageClick = () => {
+    if (menu.menuImageUrl) {
+      setIsPopupOpen(true);
+    }
+  };
+
+  const closePopup = () => {
+    setIsPopupOpen(false);
+  };
+
   return (
-    <div
-      className={`${style.menuItem} ${menu.menuIsSoldOut ? style.soldOut : ""}`}
-      onClick={onClick}
-    >
-      <div className={style.img}>
-        <img src={menu.menuImageUrl} alt={menu.menuName} />
+    <>
+      <div
+        className={`${style.menuItem} ${menu.menuIsSoldOut ? style.soldOut : ""}`}
+        onClick={onClick}
+      >
+        <div className={style.img} onClick={handleImageClick}>
+          <img src={menu.menuImageUrl} alt={menu.menuName} />
+        </div>
+        <div className={style.contents}>
+          {menu.menuIsSoldOut && <p className={style.soldOutText}>품절</p>}
+          {menu.menuIsRecommended && <Tag content="주인장 추천!" />}
+          <h4>{menu.menuName}</h4>
+          <p className={style.description}>{menu.menuDescription}</p>
+          <p className={style.price}>{menu.menuPrice.toLocaleString()}원</p>
+        </div>
       </div>
-      <div className={style.contents}>
-           {menu.menuIsSoldOut && <p className={style.soldOutText}>품절</p>}
-        {menu.menuIsRecommended && <Tag content="주인장 추천!" />}
-        <h4>{menu.menuName}</h4>
-        <p className={style.description}>{menu.menuDescription}</p>
-        <p className={style.price}>{menu.menuPrice.toLocaleString()}원</p>
-     
-      </div>
-    </div>
+
+      {isPopupOpen && (
+        <div className={style.popupOverlay} onClick={closePopup}>
+          <div className={style.popupContent} onClick={(e) => e.stopPropagation()}>
+            <img src={menu.menuImageUrl} alt={menu.menuName} />
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/pages/StoreDetail/StoreDetail.module.css
+++ b/src/pages/StoreDetail/StoreDetail.module.css
@@ -101,3 +101,33 @@
   border-radius: 20px;
   overflow: hidden;
 }
+
+.popupOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.popupContent {
+  background-color: white;
+  padding: 16px;
+  border-radius: 8px;
+  max-width: 90%;
+  max-height: 90%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.popupContent img {
+  max-width: 100%;
+  max-height: 100%;
+  border-radius: 8px;
+}

--- a/src/pages/StoreDetail/StoreDetail.tsx
+++ b/src/pages/StoreDetail/StoreDetail.tsx
@@ -18,10 +18,9 @@ const StoreDetail = () => {
   const [storeInfo, setStoreInfo] = useState<StoreResponse>();
   const [imgSlide, setImgSlide] = useState<string[]>([]);
   const [swiper, setSwiper] = useState<SwiperClass>();
-
-  const [selectedMenuBar, setSelectedMenuBar] = useState<"menu" | "map">(
-    "menu",
-  );
+  const [selectedMenuBar, setSelectedMenuBar] = useState<"menu" | "map">("menu");
+  const [isPopupOpen, setIsPopupOpen] = useState(false);
+  const [popupImage, setPopupImage] = useState<string>("");
 
   const fetchStoreInfo = async () => {
     try {
@@ -37,8 +36,19 @@ const StoreDetail = () => {
   const handlePrev = () => {
     swiper?.slidePrev();
   };
+
   const handleNext = () => {
     swiper?.slideNext();
+  };
+
+  const handleImageClick = (imageUrl: string) => {
+    setPopupImage(imageUrl);
+    setIsPopupOpen(true);
+  };
+
+  const closePopup = () => {
+    setIsPopupOpen(false);
+    setPopupImage("");
   };
 
   useEffect(() => {
@@ -63,18 +73,22 @@ const StoreDetail = () => {
               setSwiper(e);
             }}
           >
-          {imgSlide.map((slide, index) => {
-            const fixedUrl =
-              slide.startsWith("https:/") && !slide.startsWith("https://")
-                ? slide.replace("https:/", "https://")
-                : slide;
+            {imgSlide.map((slide, index) => {
+              const fixedUrl =
+                slide.startsWith("https:/") && !slide.startsWith("https://")
+                  ? slide.replace("https:/", "https://")
+                  : slide;
 
-            return (
-              <SwiperSlide key={index} className={style.imgSlide}>
-                <img src={fixedUrl} alt={`가게 이미지 ${index + 1}`}/>
-              </SwiperSlide>
-            );
-          })}
+              return (
+                <SwiperSlide
+                  key={index}
+                  className={style.imgSlide}
+                  onClick={() => handleImageClick(fixedUrl)}
+                >
+                  <img src={fixedUrl} alt={`가게 이미지 ${index + 1}`} />
+                </SwiperSlide>
+              );
+            })}
           </Swiper>
           {imgSlide.length > 1 && (
             <>
@@ -139,6 +153,14 @@ const StoreDetail = () => {
           />
         )}
       </div>
+
+      {isPopupOpen && (
+        <div className={style.popupOverlay} onClick={closePopup}>
+          <div className={style.popupContent} onClick={(e) => e.stopPropagation()}>
+            <img src={popupImage} alt="가게 이미지 확대" />
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #26 

<br>

## 📝 작업 내용
- 메뉴 사진
- 가게 소개 사진들

<br>

## 📸 스크린샷
|가게 소개 전체화면|메뉴 사진 전체화면|
|---|---|
|![가게 소개 전체화면](https://github.com/user-attachments/assets/92bc7046-3ff2-459d-a76e-5b97280cd5d1)|![메뉴 사진 전체화면](https://github.com/user-attachments/assets/4db5c3ab-880c-472f-aa00-adda36b0c107)|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - 메뉴 아이템과 매장 상세 페이지에서 이미지를 클릭하면 전체 화면 팝업으로 확대된 이미지를 볼 수 있는 기능이 추가되었습니다.
- **Style**
    - 팝업 오버레이 및 팝업 콘텐츠에 대한 스타일이 추가되어, 어두운 배경과 중앙 정렬된 흰색 팝업 창이 적용됩니다.  
    - 팝업 내 이미지는 반응형으로 표시되고, 모서리가 둥글게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->